### PR TITLE
Windows Support - Fix for platform inconsistency of path.normalize

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -111,7 +111,7 @@ class Key {
       this._buf = Buffer.concat([new Buffer('/'), this._buf])
     }
 
-    this._buf = new Buffer(path.normalize(this.toString()))
+    this._buf = new Buffer(normalizePath(this.toString()))
 
     // normalize does not remove trailing slashes
     if (this.toString().length > 1) {
@@ -364,6 +364,16 @@ function namespaceType (ns /* : string */) /* : string */ {
 function namespaceValue (ns /* : string */) /* : string */ {
   const parts = ns.split(':')
   return parts[parts.length - 1]
+}
+
+/**
+ * Normalized version of a key path
+ *
+ * @param {string} pathStr
+ * @returns {string}
+ */
+function normalizePath (pathStr /* : string */) /* : string */ {
+  return path.normalize(pathStr).replace(/\\+/g, '/');
 }
 
 module.exports = Key

--- a/src/key.js
+++ b/src/key.js
@@ -373,7 +373,7 @@ function namespaceValue (ns /* : string */) /* : string */ {
  * @returns {string}
  */
 function normalizePath (pathStr /* : string */) /* : string */ {
-  return path.normalize(pathStr).replace(/\\+/g, '/');
+  return path.normalize(pathStr).replace(/\\+/g, '/')
 }
 
 module.exports = Key

--- a/test/key.spec.js
+++ b/test/key.spec.js
@@ -8,7 +8,7 @@ const path = require('path')
 const Key = require('../src').Key
 
 const clean = (s) => {
-  let fixed = path.normalize(s)
+  let fixed = path.normalize(s).replace(/\\+/g, '/')
   if (fixed.length > 1) {
     return fixed.replace(/\/$/, '')
   }


### PR DESCRIPTION
A method of fixing the inconsistency without changing the whole format of key paths.

This method passes all test on Windows 10.