### PR TITLE
Prefer path.posix for consistent `/` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/ipfs/interface-datastore#readme",
   "devDependencies": {
     "aegir": "^11.0.2",
-    "chai": "^4.0.1",
+    "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "flow-bin": "^0.47.0"
   },
@@ -54,7 +54,8 @@
     "David Dias <daviddias.p@gmail.com>",
     "Erin Dachtler <download333@gmail.com>",
     "Juan Batiz-Benet <juan@benet.ai>",
-    "dignifiedquire <dignifiedquire@gmail.com>"
+    "dignifiedquire <dignifiedquire@gmail.com>",
+    "Justin Chase <justin.m.chase@gmail.com>"
   ],
   "bundleDependencies": []
 }

--- a/src/key.js
+++ b/src/key.js
@@ -1,7 +1,7 @@
 /* @flow */
 'use strict'
 
-const path = require('path')
+const path = require('./path')
 const uuid = require('uuid/v4')
 
 const pathSepS = path.sep

--- a/src/path.js
+++ b/src/path.js
@@ -1,3 +1,6 @@
+/* @flow */
+'use strict'
+
 const path = require('path')
 
 // Fallback to `path` because `path.posix` may not be available in browsers.

--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,4 @@
+const path = require('path')
+
+// Fallback to `path` because `path.posix` may not be available in browsers.
+module.exports = path.posix || path

--- a/src/tests.js
+++ b/src/tests.js
@@ -12,7 +12,7 @@ const parallel = require('async/parallel')
 const map = require('async/map')
 const each = require('async/each')
 const crypto = require('libp2p-crypto')
-const path = require('path')
+const path = require('./path')
 
 const Key = require('../src').Key
 const n = (p) => path.normalize(p)

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 
 const pull = require('pull-stream')
 const Source = require('pull-defer/source')
-const path = require('path')
+const path = require('./path')
 const os = require('os')
 const uuid = require('uuid/v4')
 

--- a/test/key.spec.js
+++ b/test/key.spec.js
@@ -3,7 +3,7 @@
 'use strict'
 
 const expect = require('chai').expect
-const path = require('path')
+const path = require('../src/path')
 
 const Key = require('../src').Key
 


### PR DESCRIPTION
I'm trying to use this module on windows and it is having some issues. I got the latest version `0.2.2`  which had some fixes for windows paths but the tests were still failing.

The problem appears to be that while the platform specific `path.sep` is now used all of the tests and probably all calling code uses hard coded paths in a lot of case such as `foo/bar`. This can cause errors unless you specifically fix up all calling code to use `path.join('foo', 'bar')` in all cases also.

It's my opinion that its actually better to just adopt an always forward slash approach, even on windows. Always use `path.posix` or hard coded `/`'s in your code. Especially since you have the actual file system access modularized and abstracted, then you can just normalize the path at the points of `fs` usage to either forward or back slashes if needed.

This change alters this module to always use the posix path apis and allows tests to pass. I have also linked this codebase to `datastore-core` code base, which is dependent on this module and it allows the tests in that repo to pass on windows without any other changes needed.