### PR TITLE
pathSepS is broken on Windows

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -4,7 +4,7 @@
 const path = require('path')
 const uuid = require('uuid/v4')
 
-const pathSepS = path.sep
+const pathSepS = '/'
 const pathSep = new Buffer(pathSepS, 'utf8')[0]
 
 /**


### PR DESCRIPTION
Other parts of IPFS (specifically, for example, libipfs-kad-dht) assume that pathSep is '/'. This code assumes pathSep is determined by the operating system and therefore on Windows will be '\'.

This patch is probably not the best solution to the problem (perhaps you should support both common path separators on all platforms?) but allows me to at least keep using libp2p on Windows for the time being.