### PR TITLE
docs: add store.has to readme as it is in the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ Also, every namespace can be parametrized to embed relevant object information. 
 
 These methods will be present on every datastore. `Key` always means an instance of the above mentioned Key type. Every datastore is generic over the `Value` type, though currently all backing implementations are implemented only for [`Buffer`](https://nodejs.org/docs/latest/api/buffer.html).
 
+### `has(key, callback)`
+
+- `key: Key`
+- `callback: function(Error, bool)`
+
+Check for the existence of a given key
+
+```js
+store.has(new Key('awesome'), (err, exists) => {
+  if (err) {
+    throw err
+  }
+  console.log('is it there', exists)
+})
+```
+
 ### `put(key, value, callback)`
 
 - `key: Key`


### PR DESCRIPTION
In the process of creating another store (s3), I noticed that the `store.has` method is in the interface test suite, but it is not in the readme. This corrects that.

connects to https://github.com/ipfs/js-ipfs-repo/issues/135