### PR TITLE
Feat/err codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
+    "err-code": "^1.1.2",
     "pull-defer": "^0.2.2",
     "pull-stream": "^3.6.1",
     "uuid": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   },
   "homepage": "https://github.com/ipfs/interface-datastore#readme",
   "devDependencies": {
-    "aegir": "^12.2.0",
+    "aegir": "^15.1.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "flow-bin": "^0.60.1"
+    "flow-bin": "~0.60.1"
   },
   "dependencies": {
-    "async": "^2.6.0",
+    "async": "^2.6.1",
     "err-code": "^1.1.2",
-    "pull-defer": "^0.2.2",
-    "pull-stream": "^3.6.1",
-    "uuid": "^3.1.0"
+    "pull-defer": "~0.2.3",
+    "pull-stream": "^3.6.9",
+    "uuid": "^3.3.2"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const errcode = require('err-code')
+
+module.exports.ERR_DB_CANNOT_OPEN = (err) => {
+  err = err || new Error('Cannot open database')
+  return errcode(err, 'ERR_CANNOT_OPEN_DB')
+}
+
+module.exports.ERR_DB_DELETE_FAILED = (err) => {
+  err = err || new Error('Delete failed')
+  return errcode(err, 'ERR_DB_DELETE_FAILED')
+}
+
+module.exports.ERR_DB_WRITE_FAILED = (err) => {
+  err = err || new Error('Write failed')
+  return errcode(err, 'ERR_DB_WRITE_FAILED')
+}
+
+module.exports.ERR_NOT_FOUND = (err) => {
+  err = err || new Error('Not Found')
+  return errcode(err, 'ERR_NOT_FOUND')
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -2,22 +2,22 @@
 
 const errcode = require('err-code')
 
-module.exports.ERR_DB_CANNOT_OPEN = (err) => {
+module.exports.dbOpenFailedError = (err) => {
   err = err || new Error('Cannot open database')
-  return errcode(err, 'ERR_CANNOT_OPEN_DB')
+  return errcode(err, 'ERR_DB_OPEN_FAILED')
 }
 
-module.exports.ERR_DB_DELETE_FAILED = (err) => {
+module.exports.dbDeleteFailedError = (err) => {
   err = err || new Error('Delete failed')
   return errcode(err, 'ERR_DB_DELETE_FAILED')
 }
 
-module.exports.ERR_DB_WRITE_FAILED = (err) => {
+module.exports.dbWriteFailedError = (err) => {
   err = err || new Error('Write failed')
   return errcode(err, 'ERR_DB_WRITE_FAILED')
 }
 
-module.exports.ERR_NOT_FOUND = (err) => {
+module.exports.notFoundError = (err) => {
   err = err || new Error('Not Found')
   return errcode(err, 'ERR_NOT_FOUND')
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,12 @@
 const Key = require('./key')
 const MemoryDatastore = require('./memory')
 const utils = require('./utils')
+const Errors = require('./errors')
 
 exports.Key = Key
 exports.MemoryDatastore = MemoryDatastore
 exports.utils = utils
+exports.Errors = Errors
 
 /* ::
 // -- Basics

--- a/src/memory.js
+++ b/src/memory.js
@@ -10,6 +10,10 @@ const asyncFilter = require('./utils').asyncFilter
 const asyncSort = require('./utils').asyncSort
 const Key = require('./key')
 
+// Errors
+const Errors = require('./errors')
+const ERR_NOT_FOUND = Errors.ERR_NOT_FOUND
+
 class MemoryDatastore {
   /* :: data: {[key: string]: Buffer} */
 
@@ -34,7 +38,7 @@ class MemoryDatastore {
       }
 
       if (!exists) {
-        return callback(new Error('No value'))
+        return callback(ERR_NOT_FOUND())
       }
 
       callback(null, this.data[key.toString()])

--- a/src/memory.js
+++ b/src/memory.js
@@ -12,7 +12,6 @@ const Key = require('./key')
 
 // Errors
 const Errors = require('./errors')
-const ERR_NOT_FOUND = Errors.ERR_NOT_FOUND
 
 class MemoryDatastore {
   /* :: data: {[key: string]: Buffer} */
@@ -38,7 +37,7 @@ class MemoryDatastore {
       }
 
       if (!exists) {
-        return callback(ERR_NOT_FOUND())
+        return callback(Errors.notFoundError())
       }
 
       callback(null, this.data[key.toString()])

--- a/src/tests.js
+++ b/src/tests.js
@@ -111,6 +111,15 @@ module.exports = (test/* : Test */) => {
         })
       ], done)
     })
+
+    it('should return error with missing key', (done) => {
+      const k = new Key('/does/not/exist')
+      check(store).get(k, (err) => {
+        expect(err).to.exist()
+        expect(err).to.have.property('code', 'ERR_NOT_FOUND')
+        done()
+      })
+    })
   })
 
   describe('delete', () => {


### PR DESCRIPTION
* Adds error codes to allow databases to have consistent error management.
* Adds the needed errors to address https://github.com/ipfs/js-ipfs/issues/1557#issuecomment-420364416.
* Also adds the ERR_NOT_FOUND error to the memory datastore get method.

I also updated the dependencies to their latest versions.

I have also run the updated tests locally against the error implementation in datastore-fs for reference. https://github.com/ipfs/js-datastore-fs/compare/feat/err-codes?expand=1 (**note**: the ci tests will fail there until the dependency is updated)