### PR TITLE
feat: add class-is module

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   },
   "dependencies": {
     "async": "^2.6.1",
+    "class-is": "^1.1.0",
+    "err-code": "^1.1.2",
     "pull-defer": "~0.2.2",
     "pull-stream": "^3.6.8",
     "uuid": "^3.2.1"
@@ -60,5 +62,5 @@
     "tcme <hi@this-connect.me>",
     "ᴠɪᴄᴛᴏʀ ʙᴊᴇʟᴋʜᴏʟᴍ <victorbjelkholm@gmail.com>"
   ],
-  "bundleDependencies": [],
+  "bundleDependencies": []
 }

--- a/src/key.js
+++ b/src/key.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const uuid = require('uuid/v4')
+const withIs = require('class-is')
 
 const pathSepS = '/'
 const pathSepB = Buffer.from(pathSepS)
@@ -372,4 +373,4 @@ function namespaceValue (ns /* : string */) /* : string */ {
   return parts[parts.length - 1]
 }
 
-module.exports = Key
+module.exports = withIs(Key, { className: 'Key', symbolName: '@ipfs/interface-datastore/key' })

--- a/src/key.js
+++ b/src/key.js
@@ -84,7 +84,7 @@ class Key {
    *
    */
   static withNamespaces (list /* : Array<string> */) /* : Key */ {
-    return new Key(list.join(pathSepS))
+    return new _Key(list.join(pathSepS))
   }
 
   /**
@@ -98,7 +98,7 @@ class Key {
    *
    */
   static random () /* : Key */ {
-    return new Key(uuid().replace(/-/g, ''))
+    return new _Key(uuid().replace(/-/g, ''))
   }
 
   /**
@@ -237,7 +237,7 @@ class Key {
    * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
    */
   instance (s /* : string */) /* : Key */ {
-    return new Key(this.toString() + ':' + s)
+    return new _Key(this.toString() + ':' + s)
   }
 
   /**
@@ -256,7 +256,7 @@ class Key {
       p += pathSepS
     }
     p += this.type()
-    return new Key(p)
+    return new _Key(p)
   }
 
   /**
@@ -272,10 +272,10 @@ class Key {
   parent () /* : Key */ {
     const list = this.list()
     if (list.length === 1) {
-      return new Key(pathSepS)
+      return new _Key(pathSepS)
     }
 
-    return new Key(list.slice(0, -1).join(pathSepS))
+    return new _Key(list.slice(0, -1).join(pathSepS))
   }
 
   /**
@@ -296,7 +296,7 @@ class Key {
       return this
     }
 
-    return new Key(this.toString() + key.toString(), false)
+    return new _Key(this.toString() + key.toString(), false)
   }
 
   /**
@@ -373,4 +373,6 @@ function namespaceValue (ns /* : string */) /* : string */ {
   return parts[parts.length - 1]
 }
 
-module.exports = withIs(Key, { className: 'Key', symbolName: '@ipfs/interface-datastore/key' })
+const _Key = withIs(Key, { className: 'Key', symbolName: '@ipfs/interface-datastore/key' })
+
+module.exports = _Key


### PR DESCRIPTION
The `instance of` fails when using different versions of a module. This way, we end up with problems using this in other places, such as [js-ipfs/core/ipns/publisher.js#L93](https://github.com/ipfs/js-ipfs/blob/master/src/core/ipns/publisher.js#L93).

In the context of [js-ipfs/issues/1615](https://github.com/ipfs/js-ipfs/issues/1615)