### PR TITLE
docs: add nonatomic option to datastore.put

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ Object in the form with the following optional properties
 - `offset: Number` (optional) - skip this many records at the beginning
 - `keysOnly: Boolean` (optional) - Only return keys, no values.
 
-### `batch()`
+### `batch(options)`
+
+- `options: Object` (optional) - An object that may contain the following keys:
+  - `nonatomic: boolean` - If true, `Value` should be stored nonatomically if supported by the implementation (defaults to `false`)
 
 This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
 
@@ -207,12 +210,10 @@ await b.commit()
 console.log('put 100 values')
 ```
 
-#### `put(key, value, options)`
+#### `put(key, value)`
 
 - `key: Key`
 - `value: Value`
-- `options: Object` (optional) - An object that may contain the following keys:
-  - `nonatomic: boolean` - If true, `Value` should be stored nonatomically if supported by the implementation (defaults to `false`)
 
 Queue a put operation to the store.
 

--- a/README.md
+++ b/README.md
@@ -127,15 +127,19 @@ const exists = await store.has(new Key('awesome'))
 console.log('is it there', exists)
 ```
 
-### `put(key, value)` -> `Promise`
+### `put(key, value, options)` -> `Promise`
 
 - `key: Key`
 - `value: Value`
+- `options: Object` (optional) - An object that may contain the following keys:
+  - `nonatomic: boolean` - If true, `Value` should be stored nonatomically if supported by the implementation (defaults to `false`)
 
 Store a value with the given key.
 
 ```js
-await store.put(new Key('awesome'), new Buffer('datastores'))
+await store.put(new Key('awesome'), new Buffer('datastores'), {
+  nonatomic: true
+})
 console.log('put content')
 ```
 
@@ -203,10 +207,12 @@ await b.commit()
 console.log('put 100 values')
 ```
 
-#### `put(key, value)`
+#### `put(key, value, options)`
 
 - `key: Key`
 - `value: Value`
+- `options: Object` (optional) - An object that may contain the following keys:
+  - `nonatomic: boolean` - If true, `Value` should be stored nonatomically if supported by the implementation (defaults to `false`)
 
 Queue a put operation to the store.
 

--- a/src/memory.js
+++ b/src/memory.js
@@ -13,7 +13,7 @@ class MemoryDatastore {
 
   async open () {}
 
-  async put (key, val) { // eslint-disable-line require-await
+  async put (key, val, options) { // eslint-disable-line require-await
     this.data[key.toString()] = val
   }
 
@@ -31,7 +31,7 @@ class MemoryDatastore {
     delete this.data[key.toString()]
   }
 
-  batch () {
+  batch (options) {
     let puts = []
     let dels = []
 


### PR DESCRIPTION
Allow passing an option to `datastore.put` that instructs the datastore to use a nonatomic method of storing the passed value if it is capable of doing so.