### PR TITLE
feat: add streaming methods and allow passing AbortSignals

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "devDependencies": {
     "aegir": "^21.4.5",
     "chai": "^4.1.2",
-    "dirty-chai": "^2.0.1"
+    "dirty-chai": "^2.0.1",
+    "it-all": "^1.0.2",
+    "it-drain": "^1.0.1"
   },
   "dependencies": {
     "buffer": "^5.5.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -21,3 +21,8 @@ module.exports.notFoundError = (err) => {
   err = err || new Error('Not Found')
   return errcode(err, 'ERR_NOT_FOUND')
 }
+
+module.exports.abortedError = (err) => {
+  err = err || new Error('Aborted')
+  return errcode(err, 'ERR_ABORTED')
+}

--- a/src/key.js
+++ b/src/key.js
@@ -68,7 +68,7 @@ class Key {
    * @returns {String}
    */
   get [Symbol.toStringTag] () {
-    return `[Key ${this.toString()}]`
+    return `Key(${this.toString()})`
   }
 
   /**


### PR DESCRIPTION
Adds methods that take and return async iterators in order to allow calling code to control levels of concurrency when using datastores.

These methods take and return async iterators, allowing us to use them in pipelines.

Also adds `options` objects to every call, allowing us to pass in `AbortSignal`s.