### PR TITLE
fix: remove .has method from interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,37 +27,34 @@
   - [Test suite](#test-suite)
   - [Keys](#keys)
 - [API](#api)
-  - [`has(key, [options])` -> `Promise<Boolean>`](#haskey-options---promiseboolean)
+  - [`put(key, value, [options])` -> `Promise`](#putkey-value-options---promise)
     - [Arguments](#arguments)
     - [Example](#example)
-  - [`put(key, value, [options])` -> `Promise`](#putkey-value-options---promise)
+  - [`putMany(source, [options])` -> `AsyncIterator<{ key: Key, value: Buffer }>`](#putmanysource-options---asynciterator-key-key-value-buffer-)
     - [Arguments](#arguments-1)
     - [Example](#example-1)
-  - [`putMany(source, [options])` -> `AsyncIterator<{ key: Key, value: Buffer }>`](#putmanysource-options---asynciterator-key-key-value-buffer-)
+  - [`get(key, [options])` -> `Promise<Buffer>`](#getkey-options---promisebuffer)
     - [Arguments](#arguments-2)
     - [Example](#example-2)
-  - [`get(key, [options])` -> `Promise<Buffer>`](#getkey-options---promisebuffer)
+  - [`getMany(source, [options])` -> `AsyncIterator<Buffer>`](#getmanysource-options---asynciteratorbuffer)
     - [Arguments](#arguments-3)
     - [Example](#example-3)
-  - [`getMany(source, [options])` -> `AsyncIterator<Buffer>`](#getmanysource-options---asynciteratorbuffer)
+  - [`delete(key, [options])` -> `Promise`](#deletekey-options---promise)
     - [Arguments](#arguments-4)
     - [Example](#example-4)
-  - [`delete(key, [options])` -> `Promise`](#deletekey-options---promise)
+  - [`deleteMany(source, [options])` -> `AsyncIterator<Key>`](#deletemanysource-options---asynciteratorkey)
     - [Arguments](#arguments-5)
     - [Example](#example-5)
-  - [`deleteMany(source, [options])` -> `AsyncIterator<Key>`](#deletemanysource-options---asynciteratorkey)
+  - [`query(query, [options])` -> `AsyncIterable<Buffer>`](#queryquery-options---asynciterablebuffer)
     - [Arguments](#arguments-6)
     - [Example](#example-6)
-  - [`query(query, [options])` -> `AsyncIterable<Buffer>`](#queryquery-options---asynciterablebuffer)
-    - [Arguments](#arguments-7)
-    - [Example](#example-7)
   - [`batch()`](#batch)
-    - [Example](#example-8)
+    - [Example](#example-7)
     - [`put(key, value)`](#putkey-value)
     - [`delete(key)`](#deletekey)
     - [`commit([options])` -> `Promise<void>`](#commitoptions---promisevoid)
-    - [Arguments](#arguments-8)
-    - [Example](#example-9)
+    - [Arguments](#arguments-7)
+    - [Example](#example-8)
   - [`open()` -> `Promise`](#open---promise)
   - [`close()` -> `Promise`](#close---promise)
 - [Contribute](#contribute)
@@ -201,30 +198,6 @@ Also, every namespace can be parameterized to embed relevant object information.
 
 Implementations of this interface should make the following methods available:
 
-### `has(key, [options])` -> `Promise<Boolean>`
-
-Check for the existence of a given key
-
-#### Arguments
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | [Key][] | The key to check the existance of |
-| options | [Object][] | An options object, all properties are optional |
-| options.signal | [AbortSignal][] | A way to signal that the caller is no longer interested in the outcome of this operation |
-
-#### Example
-
-```js
-const exists = await store.has(new Key('awesome'))
-
-if (exists) {
-  console.log('it is there')
-} else {
-  console.log('it is not there')
-}
-```
-
 ### `put(key, value, [options])` -> `Promise`
 
 Store a value with the given key.
@@ -270,6 +243,8 @@ for await (const { key, value } of store.putMany(source)) {
 
 ### `get(key, [options])` -> `Promise<Buffer>`
 
+Returns the stored value for the passed key.  If no value is present, a [notFoundError][] should be thrown.
+
 #### Arguments
 
 | Name | Type | Description |
@@ -289,6 +264,8 @@ console.log('got content: %s', value.toString('utf8'))
 ```
 
 ### `getMany(source, [options])` -> `AsyncIterator<Buffer>`
+
+Returns an async iterator that yields stored values for the keys in the passed `source` iterable in order.  If a value is not present, a [notFoundError][] should be thrown and the stream ended.
 
 #### Arguments
 
@@ -464,3 +441,4 @@ MIT 2017 © IPFS
 [Function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
 [Number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
 [Boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[notFoundError]: ./src/errors.js

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -63,16 +63,6 @@ class InterfaceDatastoreAdapter {
   }
 
   /**
-   * Check for the existence of a value for the passed key
-   *
-   * @param {Key} key
-   * @returns {Promise<bool>}
-   */
-  async has (key) { // eslint-disable-line require-await
-
-  }
-
-  /**
    * Remove the record for the passed key
    *
    * @param {Key} key

--- a/src/memory.js
+++ b/src/memory.js
@@ -17,14 +17,14 @@ class MemoryDatastore extends Adapter {
     this.data[key.toString()] = val
   }
 
-  async get (key) {
-    const exists = await this.has(key)
-    if (!exists) throw Errors.notFoundError()
-    return this.data[key.toString()]
-  }
+  async get (key) { // eslint-disable-line require-await
+    key = key.toString()
 
-  async has (key) { // eslint-disable-line require-await
-    return this.data[key.toString()] !== undefined
+    if (!this.data[key]) {
+      throw Errors.notFoundError()
+    }
+
+    return this.data[key]
   }
 
   async delete (key) { // eslint-disable-line require-await


### PR DESCRIPTION
The `.has` method is a trivial way of introducing race conditions into calling code as since it's async there's nothing to stop the value for the passed key being removed or added to the datastore before the next line of code is executed.

Instead the caller should just call `.get` for the key and then handle the `notFoundError` that will be thrown if there is no value present for the key.

A common use for this method is to not put values into the datastore that already exist - datastore implementations should perform this optimisation, not calling code.

BREAKING CHANGE:

- The `.has` method has been removed, call `.get` instead