### PR TITLE
chore: export types from entrypoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,14 @@
 'use strict'
 
+/**
+ * @typedef {import('./types').Datastore} Datastore
+ * @typedef {import('./types').DatastoreFactory} DatastoreFactory
+ * @typedef {import('./types').Batch} Batch
+ * @typedef {import('./types').Options} Options
+ * @typedef {import('./types').Query} Query
+ * @typedef {import('./types').Pair} Pair
+ */
+
 const Key = require('./key')
 const MemoryDatastore = require('./memory')
 const utils = require('./utils')


### PR DESCRIPTION
Adds exports from `types.ts` to `index.js` so we can import types without referencing deeply nested paths inside this module.

Instead of:

```ts
@typedef {import('interface-datastore/dist/src/types').Datastore} Datastore
```

we can do:

```ts
@typedef {import('interface-datastore').Datastore} Datastore
```

This means we can perform internal refactors of this module without risking breaking consumers in a similar way to the [recent js-multicodec breakage](https://github.com/multiformats/js-multicodec/issues/74).