### PR TITLE
fix: fix datastore factory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 /**
  * @typedef {import('./types').Datastore} Datastore
- * @typedef {import('./types').DatastoreConstructor} DatastoreConstructor
  * @typedef {import('./types').Batch} Batch
  * @typedef {import('./types').Options} Options
  * @typedef {import('./types').Query} Query

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {import('./types').Datastore} Datastore
- * @typedef {import('./types').DatastoreFactory} DatastoreFactory
+ * @typedef {import('./types').DatastoreConstructor} DatastoreConstructor
  * @typedef {import('./types').Batch} Batch
  * @typedef {import('./types').Options} Options
  * @typedef {import('./types').Query} Query

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,8 @@ export interface Batch {
   commit: (options?: Options) => Promise<void>
 }
 
-export interface DatastoreFactory {
+export interface DatastoreConstructor {
   new (): Datastore
-  prototype: Datastore
 }
 
 export interface Datastore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,8 +19,9 @@ export interface Batch {
   commit: (options?: Options) => Promise<void>
 }
 
-export interface DatastoreFactory extends Datastore {
+export interface DatastoreFactory {
   new (): Datastore
+  prototype: Datastore
 }
 
 export interface Datastore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,6 @@ export interface Batch {
   delete: (key: Key) => void
   commit: (options?: Options) => Promise<void>
 }
-
-export interface DatastoreConstructor {
-  new (): Datastore
-}
-
 export interface Datastore {
   open: () => Promise<void>
   close: () => Promise<void>


### PR DESCRIPTION
The factory reference type can't extend the Datastore interface directly.

We want the class instance to implement the interface and not the class (Object) reference.