### PR TITLE
chore: delete unused interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,10 +19,6 @@ export interface Batch {
   commit: (options?: Options) => Promise<void>
 }
 
-export interface DatastoreFactory extends Datastore {
-  new (): Datastore
-}
-
 export interface Datastore {
   open: () => Promise<void>
   close: () => Promise<void>


### PR DESCRIPTION
The DatastoreFactory interface is poorly named and not used anywhere
so let's remove it.  We can put it back in if it turns out that we
needed it after all.