### PR TITLE
Add missing Key type

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -25,6 +25,10 @@ const pathSep = pathSepB[0]
  * - `new Key('/Comedy/MontyPython/Sketch:CheeseShop/Character:Mousebender')`
  *
  */
+/**
+ * @class Key
+ * @implements {Key}
+ */
 class Key {
   /**
    * @param {string | Uint8Array} s

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,26 +1,198 @@
-import type Key from './key'
-
-export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
-export type Await<T> = Promise<T> | T
+export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>;
+export type Await<T> = Promise<T> | T;
 export interface Pair {
-  key: Key
-  value: Uint8Array
+  key: Key;
+  value: Uint8Array;
 }
 /**
  * Options for async operations.
  */
 export interface Options {
-  signal?: AbortSignal
+  signal?: AbortSignal;
 }
 
 export interface Batch {
-  put: (key: Key, value: Uint8Array) => void
-  delete: (key: Key) => void
-  commit: (options?: Options) => Promise<void>
+  put: (key: Key, value: Uint8Array) => void;
+  delete: (key: Key) => void;
+  commit: (options?: Options) => Promise<void>;
 }
+
+interface Key {
+  /**
+   * Convert to the string representation
+   * @returns {string}
+   */
+  toString(encoding: "utf8" | "utf-8" | string): string;
+  /**
+   * Return the Uint8Array representation of the key
+   */
+  uint8Array(): Uint8Array;
+  /**
+   * Return string representation of the key
+   */
+  [Symbol.toStringTag]: string;
+  /**
+   * Cleanup the current key
+   */
+  clean(): void;
+  /**
+   * Check if the given key is sorted lower than ourself.
+   */
+  less(key: Key): boolean;
+  /**
+   * Returns the key with all parts in reversed order.
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').reverse()
+   * // => Key('/Actor:JohnCleese/MontyPython/Comedy')
+   * ```
+   */
+  reverse(): Key;
+  /**
+   * Returns the `namespaces` making up this Key.
+   */
+  namespaces(): string[];
+
+  /** Returns the "base" namespace of this key.
+   *
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').baseNamespace()
+   * // => 'Actor:JohnCleese'
+   * ```
+   */
+  baseNamespace(): string;
+  /**
+   * Returns the `list` representation of this key.
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').list()
+   * // => ['Comedy', 'MontyPythong', 'Actor:JohnCleese']
+   * ```
+   */
+  list(): string[];
+
+  /**
+   * Returns the "type" of this key (value of last namespace).
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').type()
+   * // => 'Actor'
+   * ```
+   */
+  type(): string;
+  /**
+   * Returns the "name" of this key (field of last namespace).
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').name()
+   * // => 'JohnCleese'
+   * ```
+   */
+  name(): string;
+  /**
+   * Returns an "instance" of this type key (appends value to namespace).
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor').instance('JohnClesse')
+   * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+   * ```
+   */
+  instance(s: string): Key;
+  /**
+   * Returns the "path" of this key (parent + type).
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython/Actor:JohnCleese').path()
+   * // => Key('/Comedy/MontyPython/Actor')
+   * ```
+   */
+  path(): Key;
+  /**
+   * Returns the `parent` Key of this Key.
+   * @example
+   * ```js
+   * new Key("/Comedy/MontyPython/Actor:JohnCleese").parent()
+   * // => Key("/Comedy/MontyPython")
+   * ```
+   */
+  parent(): Key;
+  /**
+   * Returns the `child` Key of this Key.
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython').child(new Key('Actor:JohnCleese'))
+   * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+   * ```
+   */
+  child(key: Key): Key;
+  /**
+   * Returns whether this key is a prefix of `other`
+   * @example
+   * ```js
+   * new Key('/Comedy').isAncestorOf('/Comedy/MontyPython')
+   * // => true
+   * ```
+   */
+  isAncestorOf(other: unknown): boolean;
+  /**
+   * Returns whether this key is a contains another as prefix.
+   * @example
+   * ```js
+   * new Key('/Comedy/MontyPython').isDecendantOf('/Comedy')
+   * // => true
+   * ```
+   */
+  isDecendantOf(other: unknown): boolean;
+  /**
+   * Checks if this key has only one namespace.
+   */
+  isTopLevel(): boolean;
+
+  /**
+   * Concats one or more Keys into one new Key.
+   */
+  concat(...keys: Key[]): Key;
+}
+
+interface KeyConstructor {
+  new (s: string | Uint8Array, clean?: boolean): Key;
+  /**
+   * Constructs a key out of a namespace array.
+   *
+   * @param {Array<string>} list - The array of namespaces
+   * @returns {Key}
+   *
+   * @example
+   * ```js
+   * Key.withNamespaces(['one', 'two'])
+   * // => Key('/one/two')
+   * ```
+   */
+  withNamespaces(list: string[]): Key;
+
+  /**
+   * Returns a randomly (uuid) generated key.
+   *
+   * @returns {Key}
+   *
+   * @example
+   * ```js
+   * Key.random()
+   * // => Key('/f98719ea086343f7b71f32ea9d9d521d')
+   * ```
+   */
+  random(): Key;
+  isKey(value: any): value is Key;
+}
+
+declare var Key: KeyConstructor;
+
+export type { Key };
+
 export interface Datastore {
-  open: () => Promise<void>
-  close: () => Promise<void>
+  open: () => Promise<void>;
+  close: () => Promise<void>;
   /**
    * Store the passed value under the passed key
    *
@@ -30,7 +202,7 @@ export interface Datastore {
    * await store.put([{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }])
    * ```
    */
-  put: (key: Key, val: Uint8Array, options?: Options) => Promise<void>
+  put: (key: Key, val: Uint8Array, options?: Options) => Promise<void>;
   /**
    * Retrieve the value stored under the given key
    *
@@ -41,7 +213,7 @@ export interface Datastore {
    * // => got content: datastore
    * ```
    */
-  get: (key: Key, options?: Options) => Promise<Uint8Array>
+  get: (key: Key, options?: Options) => Promise<Uint8Array>;
   /**
    * Check for the existence of a value for the passed key
    *
@@ -56,7 +228,7 @@ export interface Datastore {
    *}
    *```
    */
-  has: (key: Key, options?: Options) => Promise<boolean>
+  has: (key: Key, options?: Options) => Promise<boolean>;
   /**
    * Remove the record for the passed key
    *
@@ -67,7 +239,7 @@ export interface Datastore {
    * console.log('deleted awesome content :(')
    * ```
    */
-  delete: (key: Key, options?: Options) => Promise<void>
+  delete: (key: Key, options?: Options) => Promise<void>;
   /**
    * Store the given key/value pairs
    *
@@ -83,7 +255,7 @@ export interface Datastore {
   putMany: (
     source: AwaitIterable<Pair>,
     options?: Options
-  ) => AsyncIterable<Pair>
+  ) => AsyncIterable<Pair>;
   /**
    * Retrieve values for the passed keys
    *
@@ -98,7 +270,7 @@ export interface Datastore {
   getMany: (
     source: AwaitIterable<Key>,
     options?: Options
-  ) => AsyncIterable<Uint8Array>
+  ) => AsyncIterable<Uint8Array>;
   /**
    * Remove values for the passed keys
    *
@@ -115,7 +287,7 @@ export interface Datastore {
   deleteMany: (
     source: AwaitIterable<Key>,
     options?: Options
-  ) => AsyncIterable<Key>
+  ) => AsyncIterable<Key>;
   /**
    * This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
    *
@@ -131,7 +303,7 @@ export interface Datastore {
    * console.log('put 100 values')
    * ```
    */
-  batch: () => Batch
+  batch: () => Batch;
   /**
    * Query the store.
    *
@@ -145,14 +317,14 @@ export interface Datastore {
    * console.log('ALL THE VALUES', list)
    * ```
    */
-  query: (q: Query, options?: Options) => AsyncIterable<Pair>
+  query: (q: Query, options?: Options) => AsyncIterable<Pair>;
 }
 
 export interface Query {
-  prefix?: string
-  filters?: Array<(item: Pair) => boolean>
-  orders?: Array<(items: Pair[]) => Await<Pair[]>>
-  limit?: number
-  offset?: number
-  keysOnly?: boolean
+  prefix?: string;
+  filters?: Array<(item: Pair) => boolean>;
+  orders?: Array<(items: Pair[]) => Await<Pair[]>>;
+  limit?: number;
+  offset?: number;
+  keysOnly?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,57 +1,59 @@
-export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>;
-export type Await<T> = Promise<T> | T;
+export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
+export type Await<T> = Promise<T> | T
 export interface Pair {
-  key: Key;
-  value: Uint8Array;
+  key: Key
+  value: Uint8Array
 }
 /**
  * Options for async operations.
  */
 export interface Options {
-  signal?: AbortSignal;
+  signal?: AbortSignal
 }
 
 export interface Batch {
-  put: (key: Key, value: Uint8Array) => void;
-  delete: (key: Key) => void;
-  commit: (options?: Options) => Promise<void>;
+  put: (key: Key, value: Uint8Array) => void
+  delete: (key: Key) => void
+  commit: (options?: Options) => Promise<void>
 }
 
 interface Key {
   /**
    * Convert to the string representation
+   *
    * @returns {string}
    */
-  toString(encoding: "utf8" | "utf-8" | string): string;
+  toString: (encoding: 'utf8' | 'utf-8' | string) => string
   /**
    * Return the Uint8Array representation of the key
    */
-  uint8Array(): Uint8Array;
+  uint8Array: () => Uint8Array
   /**
    * Return string representation of the key
    */
-  [Symbol.toStringTag]: string;
+  [Symbol.toStringTag]: string
   /**
    * Cleanup the current key
    */
-  clean(): void;
+  clean: () => void
   /**
    * Check if the given key is sorted lower than ourself.
    */
-  less(key: Key): boolean;
+  less: (key: Key) => boolean
   /**
    * Returns the key with all parts in reversed order.
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor:JohnCleese').reverse()
    * // => Key('/Actor:JohnCleese/MontyPython/Comedy')
    * ```
    */
-  reverse(): Key;
+  reverse: () => Key
   /**
    * Returns the `namespaces` making up this Key.
    */
-  namespaces(): string[];
+  namespaces: () => string[]
 
   /** Returns the "base" namespace of this key.
    *
@@ -61,102 +63,111 @@ interface Key {
    * // => 'Actor:JohnCleese'
    * ```
    */
-  baseNamespace(): string;
+  baseNamespace: () => string
   /**
    * Returns the `list` representation of this key.
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor:JohnCleese').list()
    * // => ['Comedy', 'MontyPythong', 'Actor:JohnCleese']
    * ```
    */
-  list(): string[];
+  list: () => string[]
 
   /**
    * Returns the "type" of this key (value of last namespace).
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor:JohnCleese').type()
    * // => 'Actor'
    * ```
    */
-  type(): string;
+  type: () => string
   /**
    * Returns the "name" of this key (field of last namespace).
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor:JohnCleese').name()
    * // => 'JohnCleese'
    * ```
    */
-  name(): string;
+  name: () => string
   /**
    * Returns an "instance" of this type key (appends value to namespace).
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor').instance('JohnClesse')
    * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
    * ```
    */
-  instance(s: string): Key;
+  instance: (s: string) => Key
   /**
    * Returns the "path" of this key (parent + type).
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython/Actor:JohnCleese').path()
    * // => Key('/Comedy/MontyPython/Actor')
    * ```
    */
-  path(): Key;
+  path: () => Key
   /**
    * Returns the `parent` Key of this Key.
+   *
    * @example
    * ```js
    * new Key("/Comedy/MontyPython/Actor:JohnCleese").parent()
    * // => Key("/Comedy/MontyPython")
    * ```
    */
-  parent(): Key;
+  parent: () => Key
   /**
    * Returns the `child` Key of this Key.
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython').child(new Key('Actor:JohnCleese'))
    * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
    * ```
    */
-  child(key: Key): Key;
+  child: (key: Key) => Key
   /**
    * Returns whether this key is a prefix of `other`
+   *
    * @example
    * ```js
    * new Key('/Comedy').isAncestorOf('/Comedy/MontyPython')
    * // => true
    * ```
    */
-  isAncestorOf(other: unknown): boolean;
+  isAncestorOf: (other: unknown) => boolean
   /**
    * Returns whether this key is a contains another as prefix.
+   *
    * @example
    * ```js
    * new Key('/Comedy/MontyPython').isDecendantOf('/Comedy')
    * // => true
    * ```
    */
-  isDecendantOf(other: unknown): boolean;
+  isDecendantOf: (other: unknown) => boolean
   /**
    * Checks if this key has only one namespace.
    */
-  isTopLevel(): boolean;
+  isTopLevel: () => boolean
 
   /**
    * Concats one or more Keys into one new Key.
    */
-  concat(...keys: Key[]): Key;
+  concat: (...keys: Key[]) => Key
 }
 
 interface KeyConstructor {
-  new (s: string | Uint8Array, clean?: boolean): Key;
+  new (s: string | Uint8Array, clean?: boolean): Key
   /**
    * Constructs a key out of a namespace array.
    *
@@ -169,7 +180,7 @@ interface KeyConstructor {
    * // => Key('/one/two')
    * ```
    */
-  withNamespaces(list: string[]): Key;
+  withNamespaces: (list: string[]) => Key
 
   /**
    * Returns a randomly (uuid) generated key.
@@ -182,17 +193,17 @@ interface KeyConstructor {
    * // => Key('/f98719ea086343f7b71f32ea9d9d521d')
    * ```
    */
-  random(): Key;
-  isKey(value: any): value is Key;
+  random: () => Key
+  isKey: (value: any) => value is Key
 }
 
-declare var Key: KeyConstructor;
+declare var Key: KeyConstructor
 
-export type { Key };
+export type { Key }
 
 export interface Datastore {
-  open: () => Promise<void>;
-  close: () => Promise<void>;
+  open: () => Promise<void>
+  close: () => Promise<void>
   /**
    * Store the passed value under the passed key
    *
@@ -202,7 +213,7 @@ export interface Datastore {
    * await store.put([{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }])
    * ```
    */
-  put: (key: Key, val: Uint8Array, options?: Options) => Promise<void>;
+  put: (key: Key, val: Uint8Array, options?: Options) => Promise<void>
   /**
    * Retrieve the value stored under the given key
    *
@@ -213,7 +224,7 @@ export interface Datastore {
    * // => got content: datastore
    * ```
    */
-  get: (key: Key, options?: Options) => Promise<Uint8Array>;
+  get: (key: Key, options?: Options) => Promise<Uint8Array>
   /**
    * Check for the existence of a value for the passed key
    *
@@ -228,7 +239,7 @@ export interface Datastore {
    *}
    *```
    */
-  has: (key: Key, options?: Options) => Promise<boolean>;
+  has: (key: Key, options?: Options) => Promise<boolean>
   /**
    * Remove the record for the passed key
    *
@@ -239,7 +250,7 @@ export interface Datastore {
    * console.log('deleted awesome content :(')
    * ```
    */
-  delete: (key: Key, options?: Options) => Promise<void>;
+  delete: (key: Key, options?: Options) => Promise<void>
   /**
    * Store the given key/value pairs
    *
@@ -255,7 +266,7 @@ export interface Datastore {
   putMany: (
     source: AwaitIterable<Pair>,
     options?: Options
-  ) => AsyncIterable<Pair>;
+  ) => AsyncIterable<Pair>
   /**
    * Retrieve values for the passed keys
    *
@@ -270,7 +281,7 @@ export interface Datastore {
   getMany: (
     source: AwaitIterable<Key>,
     options?: Options
-  ) => AsyncIterable<Uint8Array>;
+  ) => AsyncIterable<Uint8Array>
   /**
    * Remove values for the passed keys
    *
@@ -287,7 +298,7 @@ export interface Datastore {
   deleteMany: (
     source: AwaitIterable<Key>,
     options?: Options
-  ) => AsyncIterable<Key>;
+  ) => AsyncIterable<Key>
   /**
    * This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
    *
@@ -303,7 +314,7 @@ export interface Datastore {
    * console.log('put 100 values')
    * ```
    */
-  batch: () => Batch;
+  batch: () => Batch
   /**
    * Query the store.
    *
@@ -317,14 +328,14 @@ export interface Datastore {
    * console.log('ALL THE VALUES', list)
    * ```
    */
-  query: (q: Query, options?: Options) => AsyncIterable<Pair>;
+  query: (q: Query, options?: Options) => AsyncIterable<Pair>
 }
 
 export interface Query {
-  prefix?: string;
-  filters?: Array<(item: Pair) => boolean>;
-  orders?: Array<(items: Pair[]) => Await<Pair[]>>;
-  limit?: number;
-  offset?: number;
-  keysOnly?: boolean;
+  prefix?: string
+  filters?: Array<(item: Pair) => boolean>
+  orders?: Array<(items: Pair[]) => Await<Pair[]>>
+  limit?: number
+  offset?: number
+  keysOnly?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,187 +17,191 @@ export interface Batch {
   commit: (options?: Options) => Promise<void>
 }
 
-interface Key {
-  /**
-   * Convert to the string representation
-   *
-   * @returns {string}
-   */
-  toString: (encoding: 'utf8' | 'utf-8' | string) => string
-  /**
-   * Return the Uint8Array representation of the key
-   */
-  uint8Array: () => Uint8Array
-  /**
-   * Return string representation of the key
-   */
-  [Symbol.toStringTag]: string
-  /**
-   * Cleanup the current key
-   */
-  clean: () => void
-  /**
-   * Check if the given key is sorted lower than ourself.
-   */
-  less: (key: Key) => boolean
-  /**
-   * Returns the key with all parts in reversed order.
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').reverse()
-   * // => Key('/Actor:JohnCleese/MontyPython/Comedy')
-   * ```
-   */
-  reverse: () => Key
-  /**
-   * Returns the `namespaces` making up this Key.
-   */
-  namespaces: () => string[]
+// interface Key {
+//   _buf: Uint8Array
 
-  /** Returns the "base" namespace of this key.
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').baseNamespace()
-   * // => 'Actor:JohnCleese'
-   * ```
-   */
-  baseNamespace: () => string
-  /**
-   * Returns the `list` representation of this key.
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').list()
-   * // => ['Comedy', 'MontyPythong', 'Actor:JohnCleese']
-   * ```
-   */
-  list: () => string[]
+//   /**
+//    * Convert to the string representation
+//    *
+//    * @returns {string}
+//    */
+//   toString: (encoding: 'utf8' | 'utf-8' | string) => string
+//   /**
+//    * Return the Uint8Array representation of the key
+//    */
+//   uint8Array: () => Uint8Array
+//   /**
+//    * Return string representation of the key
+//    */
+//   [Symbol.toStringTag]: string
+//   /**
+//    * Cleanup the current key
+//    */
+//   clean: () => void
+//   /**
+//    * Check if the given key is sorted lower than ourself.
+//    */
+//   less: (key: Key) => boolean
+//   /**
+//    * Returns the key with all parts in reversed order.
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').reverse()
+//    * // => Key('/Actor:JohnCleese/MontyPython/Comedy')
+//    * ```
+//    */
+//   reverse: () => Key
+//   /**
+//    * Returns the `namespaces` making up this Key.
+//    */
+//   namespaces: () => string[]
 
-  /**
-   * Returns the "type" of this key (value of last namespace).
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').type()
-   * // => 'Actor'
-   * ```
-   */
-  type: () => string
-  /**
-   * Returns the "name" of this key (field of last namespace).
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').name()
-   * // => 'JohnCleese'
-   * ```
-   */
-  name: () => string
-  /**
-   * Returns an "instance" of this type key (appends value to namespace).
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor').instance('JohnClesse')
-   * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
-   * ```
-   */
-  instance: (s: string) => Key
-  /**
-   * Returns the "path" of this key (parent + type).
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython/Actor:JohnCleese').path()
-   * // => Key('/Comedy/MontyPython/Actor')
-   * ```
-   */
-  path: () => Key
-  /**
-   * Returns the `parent` Key of this Key.
-   *
-   * @example
-   * ```js
-   * new Key("/Comedy/MontyPython/Actor:JohnCleese").parent()
-   * // => Key("/Comedy/MontyPython")
-   * ```
-   */
-  parent: () => Key
-  /**
-   * Returns the `child` Key of this Key.
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython').child(new Key('Actor:JohnCleese'))
-   * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
-   * ```
-   */
-  child: (key: Key) => Key
-  /**
-   * Returns whether this key is a prefix of `other`
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy').isAncestorOf('/Comedy/MontyPython')
-   * // => true
-   * ```
-   */
-  isAncestorOf: (other: unknown) => boolean
-  /**
-   * Returns whether this key is a contains another as prefix.
-   *
-   * @example
-   * ```js
-   * new Key('/Comedy/MontyPython').isDecendantOf('/Comedy')
-   * // => true
-   * ```
-   */
-  isDecendantOf: (other: unknown) => boolean
-  /**
-   * Checks if this key has only one namespace.
-   */
-  isTopLevel: () => boolean
+//   /** Returns the "base" namespace of this key.
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').baseNamespace()
+//    * // => 'Actor:JohnCleese'
+//    * ```
+//    */
+//   baseNamespace: () => string
+//   /**
+//    * Returns the `list` representation of this key.
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').list()
+//    * // => ['Comedy', 'MontyPythong', 'Actor:JohnCleese']
+//    * ```
+//    */
+//   list: () => string[]
 
-  /**
-   * Concats one or more Keys into one new Key.
-   */
-  concat: (...keys: Key[]) => Key
-}
+//   /**
+//    * Returns the "type" of this key (value of last namespace).
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').type()
+//    * // => 'Actor'
+//    * ```
+//    */
+//   type: () => string
+//   /**
+//    * Returns the "name" of this key (field of last namespace).
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').name()
+//    * // => 'JohnCleese'
+//    * ```
+//    */
+//   name: () => string
+//   /**
+//    * Returns an "instance" of this type key (appends value to namespace).
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor').instance('JohnClesse')
+//    * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+//    * ```
+//    */
+//   instance: (s: string) => Key
+//   /**
+//    * Returns the "path" of this key (parent + type).
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython/Actor:JohnCleese').path()
+//    * // => Key('/Comedy/MontyPython/Actor')
+//    * ```
+//    */
+//   path: () => Key
+//   /**
+//    * Returns the `parent` Key of this Key.
+//    *
+//    * @example
+//    * ```js
+//    * new Key("/Comedy/MontyPython/Actor:JohnCleese").parent()
+//    * // => Key("/Comedy/MontyPython")
+//    * ```
+//    */
+//   parent: () => Key
+//   /**
+//    * Returns the `child` Key of this Key.
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython').child(new Key('Actor:JohnCleese'))
+//    * // => Key('/Comedy/MontyPython/Actor:JohnCleese')
+//    * ```
+//    */
+//   child: (key: Key) => Key
+//   /**
+//    * Returns whether this key is a prefix of `other`
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy').isAncestorOf('/Comedy/MontyPython')
+//    * // => true
+//    * ```
+//    */
+//   isAncestorOf: (other: unknown) => boolean
+//   /**
+//    * Returns whether this key is a contains another as prefix.
+//    *
+//    * @example
+//    * ```js
+//    * new Key('/Comedy/MontyPython').isDecendantOf('/Comedy')
+//    * // => true
+//    * ```
+//    */
+//   isDecendantOf: (other: unknown) => boolean
+//   /**
+//    * Checks if this key has only one namespace.
+//    */
+//   isTopLevel: () => boolean
 
-interface KeyConstructor {
-  new (s: string | Uint8Array, clean?: boolean): Key
-  /**
-   * Constructs a key out of a namespace array.
-   *
-   * @param {Array<string>} list - The array of namespaces
-   * @returns {Key}
-   *
-   * @example
-   * ```js
-   * Key.withNamespaces(['one', 'two'])
-   * // => Key('/one/two')
-   * ```
-   */
-  withNamespaces: (list: string[]) => Key
+//   /**
+//    * Concats one or more Keys into one new Key.
+//    */
+//   concat: (...keys: Key[]) => Key
+// }
 
-  /**
-   * Returns a randomly (uuid) generated key.
-   *
-   * @returns {Key}
-   *
-   * @example
-   * ```js
-   * Key.random()
-   * // => Key('/f98719ea086343f7b71f32ea9d9d521d')
-   * ```
-   */
-  random: () => Key
-  isKey: (value: any) => value is Key
-}
+// interface KeyConstructor {
+//   new (s: string | Uint8Array, clean?: boolean): Key
+//   /**
+//    * Constructs a key out of a namespace array.
+//    *
+//    * @param {Array<string>} list - The array of namespaces
+//    * @returns {Key}
+//    *
+//    * @example
+//    * ```js
+//    * Key.withNamespaces(['one', 'two'])
+//    * // => Key('/one/two')
+//    * ```
+//    */
+//   withNamespaces: (list: string[]) => Key
 
-declare var Key: KeyConstructor
+//   /**
+//    * Returns a randomly (uuid) generated key.
+//    *
+//    * @returns {Key}
+//    *
+//    * @example
+//    * ```js
+//    * Key.random()
+//    * // => Key('/f98719ea086343f7b71f32ea9d9d521d')
+//    * ```
+//    */
+//   random: () => Key
+//   isKey: (value: any) => value is Key
+// }
+
+// declare var Key: KeyConstructor
+
+type Key = any
 
 export type { Key }
 


### PR DESCRIPTION
**Update**

Turned this into a draft as Symbol keys requires Typescript 4.2 which is supposed to be released end ob February.

For more context, see https://stackoverflow.com/questions/59118271/using-symbol-as-object-key-type-in-typescript

---

Typescript seems to be unable to import under certain conditions types from `.js` files.

This PR adds the missing type and makes sure that Typescript does not try to import types from `.js`.

**Background**

Missing Key type breaks type checking with Typescript on libp2p 0.30.