### PR TITLE
chore: remove web-encoding

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -2,7 +2,6 @@
 
 const { nanoid } = require('nanoid')
 const { utf8Encoder, utf8Decoder } = require('./utils')
-const TextDecoder = require('ipfs-utils/src/text-decoder')
 
 const symbol = Symbol.for('@ipfs/interface-datastore/key')
 const pathSepS = '/'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const tempdir = require('ipfs-utils/src/temp-dir')
-const TextEncoder = require('ipfs-utils/src/text-encoder')
-const TextDecoder = require('ipfs-utils/src/text-decoder')
 
 /**
  * @template T


### PR DESCRIPTION
TextEncoder and TextDecoder are globals everywhere we run so do not pull them in from ipfs-utils.