### PR TITLE
feat: split .query into .query and .queryKeys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npx nyc --reporter=lcov aegir test -t node -- --bail
+      - run: npx aegir test -t node --cov --bail
       - uses: codecov/codecov-action@v1
   test-chrome:
     needs: check
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail -- --browsers FirefoxHeadless
+      - run: npx aegir test -t browser -t webworker --bail -- --browser firefox
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "release": "aegir release --docs",
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
-    "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider codecov",
+    "coverage": "aegir test --cov",
     "docs": "aegir docs"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "homepage": "https://github.com/ipfs/interface-datastore#readme",
   "devDependencies": {
     "@types/err-code": "^2.0.0",
-    "aegir": "^33.1.0"
+    "aegir": "^33.1.0",
+    "it-map": "^1.0.5"
   },
   "dependencies": {
     "err-code": "^3.0.1",
@@ -47,7 +48,6 @@
     "it-all": "^1.0.2",
     "it-drain": "^1.0.1",
     "it-filter": "^1.0.2",
-    "it-map": "^1.0.5",
     "it-take": "^1.0.1",
     "nanoid": "^3.0.2",
     "uint8arrays": "^2.1.5"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "aegir build --no-bundle && cp src/types.d.ts dist/src/types.d.ts",
+    "prepare": "aegir build --no-bundle",
     "lint": "aegir lint",
     "test": "aegir test",
     "test:node": "aegir test --target node",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.2",
     "it-drain": "^1.0.1",
-    "nanoid": "^3.0.2"
+    "it-filter": "^1.0.2",
+    "it-map": "^1.0.5",
+    "it-take": "^1.0.1",
+    "nanoid": "^3.0.2",
+    "uint8arrays": "^2.1.5"
   },
   "eslintConfig": {
     "extends": "ipfs"

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -12,7 +12,7 @@ const take = require('it-take')
  * @typedef {import('./types').Datastore} Datastore
  * @typedef {import('./types').Options} Options
  * @typedef {import('./types').Query} Query
- * @typedef {import('./types').KeysQuery} KeysQuery
+ * @typedef {import('./types').KeyQuery} KeyQuery
  * @typedef {import('./types').Batch} Batch
  */
 
@@ -181,7 +181,7 @@ class Adapter {
   }
 
   /**
-   * @param {KeysQuery} q
+   * @param {KeyQuery} q
    * @param {Options} [options]
    */
   queryKeys (q, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@
  * @typedef {import('./types').Batch} Batch
  * @typedef {import('./types').Options} Options
  * @typedef {import('./types').Query} Query
+ * @typedef {import('./types').QueryFilter} QueryFilter
+ * @typedef {import('./types').QueryOrder} QueryOrder
+ * @typedef {import('./types').KeyQuery} KeyQuery
+ * @typedef {import('./types').KeyQueryFilter} KeyQueryFilter
+ * @typedef {import('./types').KeyQueryOrder} KeyQueryOrder
  * @typedef {import('./types').Pair} Pair
  */
 

--- a/src/key.js
+++ b/src/key.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const { nanoid } = require('nanoid')
-const { utf8Encoder, utf8Decoder } = require('./utils')
+
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const symbol = Symbol.for('@ipfs/interface-datastore/key')
 const pathSepS = '/'
-const pathSepB = utf8Encoder.encode(pathSepS)
+const pathSepB = new TextEncoder().encode(pathSepS)
 const pathSep = pathSepB[0]
 
 /**
@@ -31,7 +33,7 @@ class Key {
    */
   constructor (s, clean) {
     if (typeof s === 'string') {
-      this._buf = utf8Encoder.encode(s)
+      this._buf = uint8ArrayFromString(s)
     } else if (s instanceof Uint8Array) {
       this._buf = s
     } else {
@@ -54,15 +56,11 @@ class Key {
   /**
    * Convert to the string representation
    *
-   * @param {string} [encoding='utf8'] - The encoding to use.
+   * @param {import('uint8arrays/to-string').SupportedEncodings} [encoding='utf8'] - The encoding to use.
    * @returns {string}
    */
   toString (encoding = 'utf8') {
-    if (encoding === 'utf8' || encoding === 'utf-8') {
-      return utf8Decoder.decode(this._buf)
-    }
-
-    return new TextDecoder(encoding).decode(this._buf)
+    return uint8ArrayToString(this._buf, encoding)
   }
 
   /**

--- a/src/memory.js
+++ b/src/memory.js
@@ -65,6 +65,11 @@ class MemoryDatastore extends Adapter {
     yield * Object.entries(this.data)
       .map(([key, value]) => ({ key: new Key(key), value }))
   }
+
+  async * _allKeys () {
+    yield * Object.entries(this.data)
+      .map(([key]) => new Key(key))
+  }
 }
 
 module.exports = MemoryDatastore

--- a/src/tests.js
+++ b/src/tests.js
@@ -472,7 +472,6 @@ module.exports = (test) => {
       ['2 filters', { filters: [filter1, filter2] }, [hello2.key]],
       ['limit', { limit: 1 }, 1],
       ['offset', { offset: 1 }, 2],
-      ['keysOnly', { keysOnly: true }, [hello.key, world.key, hello2.key]],
       ['1 order (1)', { orders: [order1] }, [hello.key, world.key, hello2.key]],
       ['1 order (reverse 1)', { orders: [order2] }, [hello2.key, world.key, hello.key]]
     ]

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -137,22 +137,49 @@ export interface Datastore {
    *
    * @example
    * ```js
-   * // retrieve __all__ values from the store
+   * // retrieve __all__ key/value pairs from the store
    * let list = []
-   * for await (const value of store.query({})) {
+   * for await (const { key, value } of store.query({})) {
    *   list.push(value)
    * }
    * console.log('ALL THE VALUES', list)
    * ```
    */
-  query: (q: Query, options?: Options) => AsyncIterable<Pair>
+   query: (query: Query, options?: Options) => AsyncIterable<Pair>
+   /**
+   * Query the store.
+   *
+   * @example
+   * ```js
+   * // retrieve __all__ keys from the store
+   * let list = []
+   * for await (const key of store.queryKeys({})) {
+   *   list.push(key)
+   * }
+   * console.log('ALL THE KEYS', key)
+   * ```
+   */
+   queryKeys: (query: KeysQuery, options?: Options) => AsyncIterable<Key>
 }
+
+export type QueryFilter = (item: Pair) => boolean
+export type QueryOrder = (a: Pair, b: Pair) => -1 | 0 | 1
 
 export interface Query {
   prefix?: string
-  filters?: Array<(item: Pair) => boolean>
-  orders?: Array<(items: Pair[]) => Await<Pair[]>>
+  filters?: QueryFilter[]
+  orders?: QueryOrder[]
   limit?: number
   offset?: number
-  keysOnly?: boolean
+}
+
+export type KeyQueryFilter = (item: Key) => boolean
+export type KeyQueryOrder = (a: Key, b: Key) => -1 | 0 | 1
+
+export interface KeysQuery {
+  prefix?: string
+  filters?: KeyQueryFilter[]
+  orders?: KeyQueryOrder[]
+  limit?: number
+  offset?: number
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -159,7 +159,7 @@ export interface Datastore {
    * console.log('ALL THE KEYS', key)
    * ```
    */
-   queryKeys: (query: KeysQuery, options?: Options) => AsyncIterable<Key>
+   queryKeys: (query: KeyQuery, options?: Options) => AsyncIterable<Key>
 }
 
 export type QueryFilter = (item: Pair) => boolean
@@ -176,7 +176,7 @@ export interface Query {
 export type KeyQueryFilter = (item: Key) => boolean
 export type KeyQueryOrder = (a: Key, b: Key) => -1 | 0 | 1
 
-export interface KeysQuery {
+export interface KeyQuery {
   prefix?: string
   filters?: KeyQueryFilter[]
   orders?: KeyQueryOrder[]

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const tempdir = require('ipfs-utils/src/temp-dir')
+const all = require('it-all')
 
 /**
  * @template T
@@ -12,77 +13,19 @@ const tempdir = require('ipfs-utils/src/temp-dir')
  * @typedef {import("./types").AwaitIterable<T>} AnyIterable
  */
 
-const utf8Encoder = new TextEncoder()
-const utf8Decoder = new TextDecoder('utf8')
-
 /**
- * Filter
+ * Collect all values from the iterable and sort them using
+ * the passed sorter function
  *
  * @template T
  * @param {AnyIterable<T>} iterable
- * @param {(item: T) => PromiseOrValue<boolean>} filterer
- * @returns {AsyncIterable<T>}
- */
-const filter = (iterable, filterer) => {
-  return (async function * () {
-    for await (const value of iterable) {
-      const keep = await filterer(value)
-      if (!keep) continue
-      yield value
-    }
-  })()
-}
-
-// Not just sort, because the sorter is given all the values and should return
-// them all sorted
-/**
- * Sort All
- *
- * @template T
- * @param {AnyIterable<T>} iterable
- * @param {(items: T[]) => PromiseOrValue<T[]>} sorter
+ * @param {(a: T, b: T) => -1 | 0 | 1} sorter
  * @returns {AsyncIterable<T>}
  */
 const sortAll = (iterable, sorter) => {
   return (async function * () {
-    let values = []
-    for await (const value of iterable) values.push(value)
-    values = await sorter(values)
-    for (const value of values) yield value
-  })()
-}
-
-/**
- *
- * @template T
- * @param {AsyncIterable<T> | Iterable<T>} iterable
- * @param {number} n
- * @returns {AsyncIterable<T>}
- */
-const take = (iterable, n) => {
-  return (async function * () {
-    if (n <= 0) return
-    let i = 0
-    for await (const value of iterable) {
-      yield value
-      i++
-      if (i >= n) return
-    }
-  })()
-}
-
-/**
- *
- * @template T,O
- * @param {AsyncIterable<T> | Iterable<T>} iterable
- * @param {(item: T) => O} mapper
- * @returns {AsyncIterable<O>}
- */
-const map = (iterable, mapper) => {
-  return (async function * () {
-    for await (const value of iterable) {
-      yield mapper(value)
-    }
+    const values = await all(iterable)
+    yield * values.sort(sorter)
   })()
 }
 
@@ -96,12 +39,7 @@ const replaceStartWith = (s, r) => {
 }
 
 module.exports = {
-  map,
-  take,
   sortAll,
-  filter,
-  utf8Encoder,
-  utf8Decoder,
   tmpdir: tempdir,
   replaceStartWith
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -3,6 +3,9 @@
 
 const { expect } = require('aegir/utils/chai')
 const utils = require('../src').utils
+const filter = require('it-filter')
+const take = require('it-take')
+const map = require('it-map')
 
 describe('utils', () => {
   it('filter - sync', async () => {
@@ -12,7 +15,7 @@ describe('utils', () => {
      */
     const filterer = val => val % 2 === 0
     const res = []
-    for await (const val of utils.filter(data, filterer)) {
+    for await (const val of filter(data, filterer)) {
       res.push(val)
     }
     expect(res).to.be.eql([2, 4])
@@ -25,7 +28,7 @@ describe('utils', () => {
      */
     const filterer = val => val % 2 === 0
     const res = []
-    for await (const val of utils.filter(data, filterer)) {
+    for await (const val of filter(data, filterer)) {
       res.push(val)
     }
     expect(res).to.be.eql([2, 4])
@@ -34,9 +37,20 @@ describe('utils', () => {
   it('sortAll', async () => {
     const data = [1, 2, 3, 4]
     /**
-     * @param {number[]} vals
+     * @param {number} a
+     * @param {number} b
      */
-    const sorter = vals => vals.reverse()
+    const sorter = (a, b) => {
+      if (a < b) {
+        return 1
+      }
+
+      if (a > b) {
+        return -1
+      }
+
+      return 0
+    }
     const res = []
     for await (const val of utils.sortAll(data, sorter)) {
       res.push(val)
@@ -65,7 +79,7 @@ describe('utils', () => {
     const data = [1, 2, 3, 4]
     const n = 3
     const res = []
-    for await (const val of utils.take(data, n)) {
+    for await (const val of take(data, n)) {
       res.push(val)
     }
     expect(res).to.be.eql([1, 2, 3])
@@ -74,7 +88,7 @@ describe('utils', () => {
   it('should take nothing from iterator', async () => {
     const data = [1, 2, 3, 4]
     const n = 0
-    for await (const _ of utils.take(data, n)) { // eslint-disable-line
+    for await (const _ of take(data, n)) { // eslint-disable-line
       throw new Error('took a value')
     }
   })
@@ -86,7 +100,7 @@ describe('utils', () => {
      */
     const mapper = n => n * 2
     const res = []
-    for await (const val of utils.map(data, mapper)) {
+    for await (const val of map(data, mapper)) {
       res.push(val)
     }
     expect(res).to.be.eql([2, 4, 6, 8])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "extends": "./node_modules/aegir/src/config/tsconfig.aegir.json",
+    "extends": "aegir/src/config/tsconfig.aegir.json",
     "compilerOptions": {
         "outDir": "dist"
     },
     "include": [
-      "test", // remove this line if you don't want to type-check tests
+      "test",
       "src"
     ]
 }


### PR DESCRIPTION
The return type of the `.query` function varies depending on whether
`keysOnly` is passed as part of the query params.  This makes mapping
the return type difficult as it's dependent on the function input.

Here we:

1. Constrain the return type of `.query` to just key/value pairs
1. Add a new `.queryKeys` method that returns only keys
1. Add the implementation in the adapter to just chain to the existing `.query` method and map the result
1. Remove redundant utils
1. Remove redundant TextEncoder/Decoder exports
1. Change the query sort method to be a regular js sort function
1. Export types for query sort/filter methods