### PR TITLE
chore: implement interface-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "err-code": "^3.0.1",
+    "interface-store": "^0.0.2",
     "ipfs-utils": "^7.0.0",
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "prepare": "aegir build --no-bundle",
-    "lint": "aegir lint",
+    "lint": "aegir ts -p check && aegir lint",
     "test": "aegir test",
     "test:node": "aegir test --target node",
     "test:browser": "aegir test --target browser",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -6,10 +6,10 @@ const filter = require('it-filter')
 const take = require('it-take')
 
 /**
+ * @typedef {import('interface-store').Options} Options
  * @typedef {import('./key')} Key
  * @typedef {import('./types').Pair} Pair
  * @typedef {import('./types').Datastore} Datastore
- * @typedef {import('./types').Options} Options
  * @typedef {import('./types').Query} Query
  * @typedef {import('./types').KeyQuery} KeyQuery
  * @typedef {import('./types').Batch} Batch
@@ -17,7 +17,7 @@ const take = require('it-take')
 
 /**
  * @template O
- * @typedef {import('./types').AwaitIterable<O>} AwaitIterable
+ * @typedef {import('interface-store').AwaitIterable<O>} AwaitIterable
  */
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 /**
  * @typedef {import('./types').Datastore} Datastore
  * @typedef {import('./types').Batch} Batch
- * @typedef {import('./types').Options} Options
+ * @typedef {import('interface-store').Options} Options
  * @typedef {import('./types').Query} Query
  * @typedef {import('./types').QueryFilter} QueryFilter
  * @typedef {import('./types').QueryOrder} QueryOrder

--- a/src/memory.js
+++ b/src/memory.js
@@ -7,7 +7,7 @@ const Errors = require('./errors')
 /**
  * @typedef {import('./types').Pair} Pair
  * @typedef {import('./types').Datastore} Datastore
- * @typedef {import('./types').Options} Options
+ * @typedef {import('interface-store').Options} Options
  */
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,195 +1,48 @@
+import {
+  Pair as StorePair,
+  Batch as StoreBatch,
+  QueryFilter as StoreQueryFilter,
+  QueryOrder as StoreQueryOrder,
+  Query as StoreQuery,
+  KeyQueryFilter as StoreKeyQueryFilter,
+  KeyQueryOrder as StoreKeyQueryOrder,
+  KeyQuery as StoreKeyQuery,
+  Store
+} from 'interface-store'
 import type Key from './key'
 
-export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
-export type Await<T> = Promise<T> | T
-export interface Pair<K = Key, V = Uint8Array> {
-  key: K
-  value: V
-}
-/**
- * Options for async operations.
- */
-export interface Options {
-  signal?: AbortSignal
+export interface Pair extends StorePair<Key, Uint8Array> {
+
 }
 
-export interface Batch<K = Key, V = Uint8Array> {
-  put: (key: K, value: V) => void
-  delete: (key: K) => void
-  commit: (options?: Options) => Promise<void>
-}
-export interface Datastore<K = Key, V = Uint8Array> {
-  open: () => Promise<void>
-  close: () => Promise<void>
+export interface Batch extends StoreBatch<Key, Uint8Array> {
 
-  /**
-   * Store the passed value under the passed key
-   *
-   * @example
-   *
-   * ```js
-   * await store.put([{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }])
-   * ```
-   */
-  put: (key: K, val: V, options?: Options) => Promise<void>
-
-  /**
-   * Retrieve the value stored under the given key
-   *
-   * @example
-   * ```js
-   * const value = await store.get(new Key('awesome'))
-   * console.log('got content: %s', value.toString('utf8'))
-   * // => got content: datastore
-   * ```
-   */
-  get: (key: K, options?: Options) => Promise<V>
-
-  /**
-   * Check for the existence of a value for the passed key
-   *
-   * @example
-   * ```js
-   *const exists = await store.has(new Key('awesome'))
-   *
-   *if (exists) {
-   *  console.log('it is there')
-   *} else {
-   *  console.log('it is not there')
-   *}
-   *```
-   */
-  has: (key: K, options?: Options) => Promise<boolean>
-
-  /**
-   * Remove the record for the passed key
-   *
-   * @example
-   *
-   * ```js
-   * await store.delete(new Key('awesome'))
-   * console.log('deleted awesome content :(')
-   * ```
-   */
-  delete: (key: K, options?: Options) => Promise<void>
-
-  /**
-   * Store the given key/value pairs
-   *
-   * @example
-   * ```js
-   * const source = [{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }]
-   *
-   * for await (const { key, value } of store.putMany(source)) {
-   *   console.info(`put content for key ${key}`)
-   * }
-   * ```
-   */
-  putMany: (
-    source: AwaitIterable<Pair<K, V>>,
-    options?: Options
-  ) => AsyncIterable<Pair<K, V>>
-
-  /**
-   * Retrieve values for the passed keys
-   *
-   * @example
-   * ```js
-   * for await (const value of store.getMany([new Key('awesome')])) {
-   *   console.log('got content:', new TextDecoder('utf8').decode(value))
-   *   // => got content: datastore
-   * }
-   * ```
-   */
-  getMany: (
-    source: AwaitIterable<K>,
-    options?: Options
-  ) => AsyncIterable<V>
-
-  /**
-   * Remove values for the passed keys
-   *
-   * @example
-   *
-   * ```js
-   * const source = [new Key('awesome')]
-   *
-   * for await (const key of store.deleteMany(source)) {
-   *   console.log(`deleted content with key ${key}`)
-   * }
-   * ```
-   */
-  deleteMany: (
-    source: AwaitIterable<K>,
-    options?: Options
-  ) => AsyncIterable<K>
-
-  /**
-   * This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
-   *
-   * @example
-   * ```js
-   * const b = store.batch()
-   *
-   * for (let i = 0; i < 100; i++) {
-   *   b.put(new Key(`hello${i}`), new TextEncoder('utf8').encode(`hello world ${i}`))
-   * }
-   *
-   * await b.commit()
-   * console.log('put 100 values')
-   * ```
-   */
-  batch: () => Batch<K, V>
-
-  /**
-   * Query the store.
-   *
-   * @example
-   * ```js
-   * // retrieve __all__ key/value pairs from the store
-   * let list = []
-   * for await (const { key, value } of store.query({})) {
-   *   list.push(value)
-   * }
-   * console.log('ALL THE VALUES', list)
-   * ```
-   */
-   query: (query: Query<K, V>, options?: Options) => AsyncIterable<Pair<K, V>>
-
-   /**
-   * Query the store.
-   *
-   * @example
-   * ```js
-   * // retrieve __all__ keys from the store
-   * let list = []
-   * for await (const key of store.queryKeys({})) {
-   *   list.push(key)
-   * }
-   * console.log('ALL THE KEYS', key)
-   * ```
-   */
-   queryKeys: (query: KeyQuery<K>, options?: Options) => AsyncIterable<K>
 }
 
-export type QueryFilter<K = Key, V = Uint8Array> = (item: Pair<K, V>) => boolean
-export type QueryOrder<K = Key, V = Uint8Array> = (a: Pair<K, V>, b: Pair<K, V>) => -1 | 0 | 1
+export interface Datastore extends Store<Key, Uint8Array> {
 
-export interface Query<K = Key, V = Uint8Array> {
-  prefix?: string
-  filters?: QueryFilter<K, V>[]
-  orders?: QueryOrder<K, V>[]
-  limit?: number
-  offset?: number
 }
 
-export type KeyQueryFilter<K = Key> = (item: K) => boolean
-export type KeyQueryOrder<K = Key> = (a: K, b: K) => -1 | 0 | 1
+export interface QueryFilter extends StoreQueryFilter<Key, Uint8Array> {
 
-export interface KeyQuery<K = Key> {
-  prefix?: string
-  filters?: KeyQueryFilter<K>[]
-  orders?: KeyQueryOrder<K>[]
-  limit?: number
-  offset?: number
+}
+
+export interface QueryOrder extends StoreQueryOrder<Key, Uint8Array> {
+
+}
+
+export interface Query extends StoreQuery<Key, Uint8Array> {
+
+}
+
+export interface KeyQueryFilter extends StoreKeyQueryFilter<Key> {
+
+}
+
+export interface KeyQueryOrder extends StoreKeyQueryOrder<Key> {
+
+}
+
+export interface KeyQuery extends StoreKeyQuery<Key> {
+
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,9 +2,9 @@ import type Key from './key'
 
 export type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
 export type Await<T> = Promise<T> | T
-export interface Pair {
-  key: Key
-  value: Uint8Array
+export interface Pair<K = Key, V = Uint8Array> {
+  key: K
+  value: V
 }
 /**
  * Options for async operations.
@@ -13,14 +13,15 @@ export interface Options {
   signal?: AbortSignal
 }
 
-export interface Batch {
-  put: (key: Key, value: Uint8Array) => void
-  delete: (key: Key) => void
+export interface Batch<K = Key, V = Uint8Array> {
+  put: (key: K, value: V) => void
+  delete: (key: K) => void
   commit: (options?: Options) => Promise<void>
 }
-export interface Datastore {
+export interface Datastore<K = Key, V = Uint8Array> {
   open: () => Promise<void>
   close: () => Promise<void>
+
   /**
    * Store the passed value under the passed key
    *
@@ -30,7 +31,8 @@ export interface Datastore {
    * await store.put([{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }])
    * ```
    */
-  put: (key: Key, val: Uint8Array, options?: Options) => Promise<void>
+  put: (key: K, val: V, options?: Options) => Promise<void>
+
   /**
    * Retrieve the value stored under the given key
    *
@@ -41,7 +43,8 @@ export interface Datastore {
    * // => got content: datastore
    * ```
    */
-  get: (key: Key, options?: Options) => Promise<Uint8Array>
+  get: (key: K, options?: Options) => Promise<V>
+
   /**
    * Check for the existence of a value for the passed key
    *
@@ -56,7 +59,8 @@ export interface Datastore {
    *}
    *```
    */
-  has: (key: Key, options?: Options) => Promise<boolean>
+  has: (key: K, options?: Options) => Promise<boolean>
+
   /**
    * Remove the record for the passed key
    *
@@ -67,7 +71,8 @@ export interface Datastore {
    * console.log('deleted awesome content :(')
    * ```
    */
-  delete: (key: Key, options?: Options) => Promise<void>
+  delete: (key: K, options?: Options) => Promise<void>
+
   /**
    * Store the given key/value pairs
    *
@@ -81,9 +86,10 @@ export interface Datastore {
    * ```
    */
   putMany: (
-    source: AwaitIterable<Pair>,
+    source: AwaitIterable<Pair<K, V>>,
     options?: Options
-  ) => AsyncIterable<Pair>
+  ) => AsyncIterable<Pair<K, V>>
+
   /**
    * Retrieve values for the passed keys
    *
@@ -96,9 +102,10 @@ export interface Datastore {
    * ```
    */
   getMany: (
-    source: AwaitIterable<Key>,
+    source: AwaitIterable<K>,
     options?: Options
-  ) => AsyncIterable<Uint8Array>
+  ) => AsyncIterable<V>
+
   /**
    * Remove values for the passed keys
    *
@@ -113,9 +120,10 @@ export interface Datastore {
    * ```
    */
   deleteMany: (
-    source: AwaitIterable<Key>,
+    source: AwaitIterable<K>,
     options?: Options
-  ) => AsyncIterable<Key>
+  ) => AsyncIterable<K>
+
   /**
    * This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
    *
@@ -131,7 +139,8 @@ export interface Datastore {
    * console.log('put 100 values')
    * ```
    */
-  batch: () => Batch
+  batch: () => Batch<K, V>
+
   /**
    * Query the store.
    *
@@ -145,7 +154,8 @@ export interface Datastore {
    * console.log('ALL THE VALUES', list)
    * ```
    */
-   query: (query: Query, options?: Options) => AsyncIterable<Pair>
+   query: (query: Query<K, V>, options?: Options) => AsyncIterable<Pair<K, V>>
+
    /**
    * Query the store.
    *
@@ -159,27 +169,27 @@ export interface Datastore {
    * console.log('ALL THE KEYS', key)
    * ```
    */
-   queryKeys: (query: KeyQuery, options?: Options) => AsyncIterable<Key>
+   queryKeys: (query: KeyQuery<K>, options?: Options) => AsyncIterable<K>
 }
 
-export type QueryFilter = (item: Pair) => boolean
-export type QueryOrder = (a: Pair, b: Pair) => -1 | 0 | 1
+export type QueryFilter<K = Key, V = Uint8Array> = (item: Pair<K, V>) => boolean
+export type QueryOrder<K = Key, V = Uint8Array> = (a: Pair<K, V>, b: Pair<K, V>) => -1 | 0 | 1
 
-export interface Query {
+export interface Query<K = Key, V = Uint8Array> {
   prefix?: string
-  filters?: QueryFilter[]
-  orders?: QueryOrder[]
+  filters?: QueryFilter<K, V>[]
+  orders?: QueryOrder<K, V>[]
   limit?: number
   offset?: number
 }
 
-export type KeyQueryFilter = (item: Key) => boolean
-export type KeyQueryOrder = (a: Key, b: Key) => -1 | 0 | 1
+export type KeyQueryFilter<K = Key> = (item: K) => boolean
+export type KeyQueryOrder<K = Key> = (a: K, b: K) => -1 | 0 | 1
 
-export interface KeyQuery {
+export interface KeyQuery<K = Key> {
   prefix?: string
-  filters?: KeyQueryFilter[]
-  orders?: KeyQueryOrder[]
+  filters?: KeyQueryFilter<K>[]
+  orders?: KeyQueryOrder<K>[]
   limit?: number
   offset?: number
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,9 +7,14 @@ import {
   KeyQueryFilter as StoreKeyQueryFilter,
   KeyQueryOrder as StoreKeyQueryOrder,
   KeyQuery as StoreKeyQuery,
+  Options as StoreOptions,
   Store
 } from 'interface-store'
 import type Key from './key'
+
+export interface Options extends StoreOptions{
+
+}
 
 export interface Pair extends StorePair<Key, Uint8Array> {
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,21 +4,11 @@ const tempdir = require('ipfs-utils/src/temp-dir')
 const all = require('it-all')
 
 /**
- * @template T
- * @typedef {import("./types").Await<T>} PromiseOrValue
- */
-
-/**
- * @template T
- * @typedef {import("./types").AwaitIterable<T>} AnyIterable
- */
-
-/**
  * Collect all values from the iterable and sort them using
  * the passed sorter function
  *
  * @template T
- * @param {AnyIterable<T>} iterable
+ * @param {AsyncIterable<T> | Iterable<T>} iterable
  * @param {(a: T, b: T) => -1 | 0 | 1} sorter
  * @returns {AsyncIterable<T>}
  */


### PR DESCRIPTION
We have datastores and blockstores and blockstores are like datastores just with a different key/value types.

Instead of retyping them, make datastores generic so blockstores can be a specialisation of datastores.

The generics have defaults so this will be a backwards compatible change.